### PR TITLE
Fix wrong CircleCI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # route-cache-strategy
 
-![](https://circleci.com/gh/mizchi/cache-strategy.svg?style=shield&circle-token=eb266c3df82a27985d950994624d7cd7f23ad49d)
+![](https://circleci.com/gh/mizchi/route-cache-strategy.svg?style=shield)
 
 State cashing by routing.
 


### PR DESCRIPTION
I found a broken image link on README. Did you change the repository name and make it public at some point?

### Before

![](https://circleci.com/gh/mizchi/cache-strategy.svg?style=shield&circle-token=eb266c3df82a27985d950994624d7cd7f23ad49d)

### After

![](https://circleci.com/gh/mizchi/route-cache-strategy.svg?style=shield)